### PR TITLE
Change default runtime to latest supported nodejs10.x

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: cloudfront-invalidate-dist
 
 provider:
   name: aws
-  runtime: ${opt:runtime, 'nodejs8.10'}
+  runtime: ${opt:runtime, 'nodejs10.x'}
   memorySize: 128
   timeout: 30
   stage: ${opt:stage, 'dev'}


### PR DESCRIPTION
AWS has support for NodeJS 10.x since May 15, 2019.

https://aws.amazon.com/about-aws/whats-new/2019/05/aws_lambda_adds_support_for_node_js_v10/

Other NodeJS runtime are to-be deprecated

https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html